### PR TITLE
Fix New-Setfile Loop

### DIFF
--- a/module/puppet_testing_powershell/public/Invoke-RakeTask.ps1
+++ b/module/puppet_testing_powershell/public/Invoke-RakeTask.ps1
@@ -39,9 +39,10 @@ function Invoke-RakeTask {
     if($ForceCreateHosts) {
       $hostsParams['force'] = $true
     }
-
-    New-SetFile @hostsParams
   }
+
+  New-SetFile @hostsParams
+
   # Parse for master or agent only and set vars to match
   Set-VarsForHostsFile
   # Run test pattern

--- a/module/puppet_testing_powershell/public/Invoke-RspecTest.ps1
+++ b/module/puppet_testing_powershell/public/Invoke-RspecTest.ps1
@@ -39,9 +39,10 @@ function Invoke-RSpec {
     if($ForceCreateHosts) {
       $hostsParams['force'] = $true
     }
-
-    New-SetFile @hostsParams
   }
+
+  New-SetFile @hostsParams
+
   # Parse for master or agent only and set vars to match
   Set-VarsForHostsFile
   # Run test pattern


### PR DESCRIPTION
Moved the bundle exec command out of the loop where it was accidently placed inside the loop causing multiple invocations.