### PR TITLE
Fix New-Setfile Verbose Output

### DIFF
--- a/module/puppet_testing_powershell/public/New-SetFile.ps1
+++ b/module/puppet_testing_powershell/public/New-SetFile.ps1
@@ -49,7 +49,8 @@ function New-SetFile {
   try{
     Push-Location (Get-RepoTopLevel)
     $content = Invoke-BundleCommand -command "beaker-hostgenerator $string" -Verbose:$VerbosePreference
-    Write-Verbose "New-SetFile: Content returned: $content"
+    Write-Verbose "New-SetFile: Content returned:"
+    Write-Verbose ($content -join [Environment]::NewLine)
     Pop-Location
     Set-Content -Path $outpath -Value $content -Encoding ASCII -Verbose:$VerbosePreference
   }


### PR DESCRIPTION
Previously, the verbose output from this cmdlet was hard to read becuase line breaks were broken. This change fixes the line breaks in a way that should probably work for both Windows and Linux.